### PR TITLE
Refactor: Use tabulate to print database results in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # python_project
 python
+
+## Dependencies
+
+To use this project, you may need to install the `tabulate` library. You can install it using pip:
+
+```bash
+pip install tabulate
+```
+
+If you are using a `requirements.txt` file, add `tabulate` to it.

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -1,6 +1,7 @@
 import os
 import mysql.connector
 from dotenv import load_dotenv
+from tabulate import tabulate
 
 load_dotenv()
 
@@ -25,4 +26,5 @@ def fetch_data(query):
 # Example usage:
 if __name__ == "__main__":
     data = fetch_data("SELECT * FROM por_extracted_data LIMIT 10")
-    print(data)
+    table = tabulate(data, headers="keys", tablefmt="psql")
+    print(table)


### PR DESCRIPTION
Modifies the example usage in mysql_connector.py to format the output of the fetch_data function using the `tabulate` library. This provides a more readable, tabular format for data displayed in the console.

Also updated README.md with instructions on how to install `tabulate`.